### PR TITLE
Translate readme and FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # LibreFanControl
 
- [简体中文](./assets/zh_CN/README_zh-CN.md)
+<details>
+<summary><h3>README Translation</h3></summary>
+
+- [简体中文](./assets/zh_CN/README_zh-CN.md)
+
+</details>
+
 
 - Open source
 - Service very low on resource (~30mb)
@@ -34,7 +40,7 @@ If you have any troubles, check out the [FAQ](./assets/faq.md).
 #### Linux
 - `/etc/LibreFanControl`
 
-On Linux, maybe you will need to download `libsensors` and execute `sensors-detect`.
+On Linux, maybe you will need to download `lm-sensors` and execute `sensors-detect`.
 
 
 ## Build
@@ -49,7 +55,7 @@ The needed commands can be found in CI directory.
 - [x] Support Linux
 - [ ] Use type safe strings and icons ([moko-resources](https://github.com/icerockdev/moko-resources) ?)
 - [ ] Add a system to automatically receive updates
-- [x] Add workflow to the project (CI/CD, etc.) ([docker](https://docs.docker.com/)?) (GitHub Actions √)
+- [ ] Compile with container ([docker](https://docs.docker.com/)) 
 - [ ] Implement settings (info, help)
 - [ ] Add graph behavior (abscissa -> temp, ordinate -> fan speed)
 - [ ] Write an intelligent program to bind controls to their fans, and make a nice first config

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # LibreFanControl
 
+ [简体中文](./assets/zh_CN/README_zh-CN.md)
 
 - Open source
-- Service very low on ressource (~30mb)
+- Service very low on resource (~30mb)
 - Display sensors data on real time
 - Control fans based on custom behaviors
 - Save configuration
@@ -21,7 +22,7 @@ You will need some component of [dotnet 7](https://dotnet.microsoft.com/en-us/do
 
 You will need to run the app with admin privilege on both Linux and Windows.
 
-If you have any troubles, check out the [faq](./assets/faq.md).
+If you have any troubles, check out the [FAQ](./assets/faq.md).
 
 **Issues, enhancement requests and PR are welcomed!**
 
@@ -33,7 +34,7 @@ If you have any troubles, check out the [faq](./assets/faq.md).
 #### Linux
 - `/etc/LibreFanControl`
 
-On Linux, maybe you will need to download libsensors and execute sensors-detect.
+On Linux, maybe you will need to download `libsensors` and execute `sensors-detect`.
 
 
 ## Build
@@ -48,7 +49,7 @@ The needed commands can be found in CI directory.
 - [x] Support Linux
 - [ ] Use type safe strings and icons ([moko-resources](https://github.com/icerockdev/moko-resources) ?)
 - [ ] Add a system to automatically receive updates
-- [ ] Add workflow to the project (CI/CD, ect...) ([docker](https://docs.docker.com/) ?)
+- [x] Add workflow to the project (CI/CD, etc.) ([docker](https://docs.docker.com/)?) (GitHub Actions √)
 - [ ] Implement settings (info, help)
 - [ ] Add graph behavior (abscissa -> temp, ordinate -> fan speed)
 - [ ] Write an intelligent program to bind controls to their fans, and make a nice first config

--- a/assets/zh_CN/FAQ_zh-CN.md
+++ b/assets/zh_CN/FAQ_zh-CN.md
@@ -1,0 +1,19 @@
+# LibreFanControl FAQ
+
+
+> 什么是 `Disable control value` ?
+
+这是一个只会在 Linux 上有效果的设置。风扇控制可以有多种模式。 LibreFanControl 将他设为手动模式，但当禁用手动控制时，用户可以选择他们期望的控制模式。
+
+举个例子，这是我的芯片的驱动[网站](https://www.kernel.org/doc/html/next/hwmon/nct6775.html).
+```
+pwm[1-7]_enable
+        这个文件控制着 风扇/温度 控件的模式:
+                0 禁用风扇控制 (风扇被设为满速运行)
+                1 手动模式, 向 pwm[0-5] 写入0~255的任何值
+                2 "热巡航" 模式
+                3 "风扇速度巡航" 模式
+                4 "智能风扇 III" 模式 (仅NCT6775F)
+                5 "智能风扇 IV" 模式
+```
+

--- a/assets/zh_CN/README_zh-CN.md
+++ b/assets/zh_CN/README_zh-CN.md
@@ -1,0 +1,67 @@
+# LibreFanControl
+
+ [English](../../README.md) README.
+
+- 开源
+- 服务资源占用小 (约30mb)
+- 实时显示传感器数据
+- 基于 自定义行为 来控制风扇
+- 保存配置
+- 多平台支持(Linux/Windows)
+
+
+![mainPageV1](https://github.com/wiiznokes/LibreFanControl/assets/78230769/543af76c-137c-456d-a04e-8ebfed323178)
+
+
+
+## 需求
+你需要 [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) 的一些组件:
+
+- `ASP.NET Core Runtime`
+- `.NET Runtime`
+
+在 `Windows` 和 `Linux` 上，你都需要以管理员权限运行此应用。
+
+如果有其它问题，请去往 [常见问题 - FAQ](./FAQ_zh-CN.md) 。
+
+**欢迎提 Issues，功能建议 和 PR!**
+
+
+## 配置文件
+
+#### Windows
+- `C:\ProgramData\LibreFanControl`
+#### Linux
+- `/etc/LibreFanControl`
+
+在Linux上，你也许需要下载`libsensors`并执行 `sensors-detect`。
+
+
+## 构建
+- 在Windows上，如果你想构建这个项目，你只需要 [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) 的`SDK`。 
+- 在Linux上，你需要一个[JDK](https://jdk.java.net/java-se-ri/17).
+
+构建所需命令可以在 `CI` 目录里找到。
+
+
+## 未来计划 (无顺序)
+
+- [x] 支持 Linux
+- [ ] 使用类型安全字符串和图标 ([moko-resources](https://github.com/icerockdev/moko-resources) ?)
+- [ ] 添加自动接收更新的系统
+- [x] 添加工作流到项目 (CI/CD,etc.) ([docker](https://docs.docker.com/) ?) ( GitHub Actions √)
+- [ ] 完全实现 `设置` (信息，帮助)
+- [ ] 添加「图表」行为 (横坐标 -> 温度，纵坐标 -> 风扇速度)
+- [ ] 自动将控制绑定到对应风扇速度的程序，并预写一个好的初始配置。
+- [ ] 支持 [Flatpak](https://docs.flatpak.org/en/latest/first-build.html)
+
+## 使用的库
+
+### UI
+- [Compose Multiplatform Desktop](https://www.jetbrains.com/lp/compose-mpp/)
+- [setting-sliding-windows](https://github.com/wiiznokes/setting-sliding-windows)
+### 传感器
+##### Windows
+- [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor)
+##### Linux
+- [lm-sensors](https://github.com/lm-sensors/lm-sensors)


### PR DESCRIPTION
Hi.
I translated `README.md` and FAQ to zh_CN.
( And fixed a little syntax in README )
A question, in FAQ, you have value intro said `Thermal Cruise`, I translate it to '热巡航', which uses direct translate, so if you can give me a better translate.
Merge and mod if you want :).
And GitHub Actions is a CI/CD, so I check the box ~or~ in plans.